### PR TITLE
 Add support for laravel 7.x and 8.x, also added PHP 8 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: php
 sudo: false
 
 php:
-  - 7.2
   - 7.3
   - 7.4
+  - 8.0
 
 before_install:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Telegram Bot Package for Laravel 6.x
+# Telegram Bot Package for Laravel 6.x, 7.x, and 8.x
 
 [![Build Status](https://travis-ci.org/php-telegram-bot/laravel.svg?branch=master)](https://travis-ci.org/php-telegram-bot/laravel)
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/php-telegram-bot/laravel/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/php-telegram-bot/laravel/?b=master)

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "mockery/mockery": "~1.2",
         "phpunit/phpunit": "~8.0",
         "longman/php-code-style": "^3.0",
-        "graham-campbell/testbench": "^5.3"
+        "graham-campbell/testbench": "^5.6"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "php-telegram-bot/laravel",
     "type": "library",
-    "description": "Package to integrate PHP Telegram Bot library in Laravel 6.x",
+    "description": "Package to integrate PHP Telegram Bot library in Laravel 6.x, 7.x, and 8.x",
     "keywords": [
         "laravel",
         "telegram",
@@ -22,15 +22,16 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "illuminate/database": "^6.0|^7.0",
-        "illuminate/support": "^6.0|^7.0",
-        "longman/telegram-bot": "^0.61"
+        "php": "^7.3|^8.0",
+        "ext-json": "*",
+        "illuminate/database": "^6.0|^7.0|^8.0",
+        "illuminate/support": "^6.0|^7.0|^8.0",
+        "longman/telegram-bot": "^0.74"
     },
     "require-dev": {
         "mockery/mockery": "~1.2",
         "phpunit/phpunit": "~8.0",
-        "longman/php-code-style": "^3.0",
+        "longman/php-code-style": "^7.0",
         "graham-campbell/testbench": "^5.6"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,8 @@
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
+        <env name="PHP_TELEGRAM_BOT_API_KEY" value="123:testing"/>
+        <const name="PHPUNIT_TESTSUITE" value="true" />
     </php>
     <testsuites>
         <testsuite name="Package Test Suite">

--- a/src/Laravel/Commands/WebhookCommand.php
+++ b/src/Laravel/Commands/WebhookCommand.php
@@ -18,6 +18,10 @@ use Longman\TelegramBot\Exception\TelegramException;
 use Longman\TelegramBot\Request;
 use PhpTelegramBot\Laravel\PhpTelegramBotContract;
 
+use function json_encode;
+
+use const JSON_PRETTY_PRINT;
+
 class WebhookCommand extends Command
 {
     protected $signature = 'telegram:webhook {webhook?}

--- a/src/Laravel/Commands/WebhookCommand.php
+++ b/src/Laravel/Commands/WebhookCommand.php
@@ -98,6 +98,7 @@ class WebhookCommand extends Command
             if (! $request->isOk()) {
                 throw new TelegramException($request->getDescription());
             }
+            $this->info('Current webhook info:');
             $this->info(json_encode($request->getResult(), JSON_PRETTY_PRINT));
         } catch (TelegramException $e) {
             $this->error("Couldn't get webhook info");

--- a/src/Laravel/Migration.php
+++ b/src/Laravel/Migration.php
@@ -13,9 +13,10 @@ declare(strict_types=1);
 
 namespace PhpTelegramBot\Laravel;
 
+use Illuminate\Database\Migrations\Migration as LaravelMigration;
 use Illuminate\Support\Facades\DB;
 
-class Migration extends \Illuminate\Database\Migrations\Migration
+class Migration extends LaravelMigration
 {
     /** @var string */
     protected $prefix = '';
@@ -28,15 +29,15 @@ class Migration extends \Illuminate\Database\Migrations\Migration
     /**
      * Change column type for passed table field(s).
      *
-     * @param array  $table_columns
-     * @param string $new_type
+     * @param array  $tableColumns
+     * @param string $newType
      */
-    public function changeColumnTypes(array $table_columns, string $new_type): void
+    public function changeColumnTypes(array $tableColumns, string $newType): void
     {
         $database = DB::connection()->getDatabaseName();
         $prefix   = DB::connection()->getTablePrefix() . $this->prefix;
 
-        foreach ($table_columns as $table => $columns) {
+        foreach ($tableColumns as $table => $columns) {
             foreach ($columns as $column) {
                 // Preserve column comment and nullable state.
                 $props = DB::selectOne('
@@ -50,7 +51,7 @@ class Migration extends \Illuminate\Database\Migrations\Migration
 
                 $comment  = $props->COLUMN_COMMENT;
                 $nullable = $props->IS_NULLABLE === 'YES' ? 'NULL' : 'NOT NULL';
-                DB::statement("ALTER TABLE `{$prefix}{$table}` CHANGE `{$column}` `{$column}` {$new_type} {$nullable} COMMENT '{$comment}'");
+                DB::statement("ALTER TABLE `{$prefix}{$table}` CHANGE `{$column}` `{$column}` {$newType} {$nullable} COMMENT '{$comment}'");
             }
         }
     }

--- a/src/Laravel/ServiceProvider.php
+++ b/src/Laravel/ServiceProvider.php
@@ -40,7 +40,7 @@ class ServiceProvider extends LaravelServiceProvider
         // Append the default settings
         $this->mergeConfigFrom(
             __DIR__ . '/../config/config.php',
-            'phptelegrambot'
+            'phptelegrambot',
         );
 
         $this->publishes([
@@ -67,8 +67,8 @@ class ServiceProvider extends LaravelServiceProvider
 
             // Set command related configs
             if (! empty($config['commands']['configs'])) {
-                foreach ($config['commands']['configs'] as $command_name => $command_config) {
-                    $bot->setCommandConfig($command_name, $command_config);
+                foreach ($config['commands']['configs'] as $commandName => $commandConfig) {
+                    $bot->setCommandConfig($commandName, $commandConfig);
                 }
             }
 

--- a/src/database/migrations/2020_05_18_010919_convert_datetime_to_timetamp.php
+++ b/src/database/migrations/2020_05_18_010919_convert_datetime_to_timetamp.php
@@ -7,7 +7,7 @@ use PhpTelegramBot\Laravel\Migration;
 class ConvertDatetimeToTimetamp extends Migration
 {
     /** @var array[] Fields that require DATETIME to TIMESTAMP conversion. */
-    private $table_columns = [
+    private $tableColumns = [
         'callback_query'       => ['created_at'],
         'chosen_inline_result' => ['created_at'],
         'edited_message'       => ['edit_date'],
@@ -18,11 +18,11 @@ class ConvertDatetimeToTimetamp extends Migration
 
     public function up(): void
     {
-        $this->changeColumnTypes($this->table_columns, 'TIMESTAMP NULL DEFAULT NULL');
+        $this->changeColumnTypes($this->tableColumns, 'TIMESTAMP NULL DEFAULT NULL');
     }
 
     public function down(): void
     {
-        $this->changeColumnTypes($this->table_columns, 'DATETIME NULL DEFAULT NULL');
+        $this->changeColumnTypes($this->tableColumns, 'DATETIME NULL DEFAULT NULL');
     }
 }

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -27,7 +27,7 @@ $root = realpath(dirname(dirname(__FILE__)));
  */
 if (! file_exists($root . '/vendor/autoload.php')) {
     throw new Exception(
-        'Please run "php composer.phar install --dev" in root directory to setup unit test dependencies before running the tests'
+        'Please run "php composer.phar install --dev" in root directory to setup unit test dependencies before running the tests',
     );
 }
 

--- a/tests/Unit/AbstractTestCase.php
+++ b/tests/Unit/AbstractTestCase.php
@@ -12,10 +12,9 @@ abstract class AbstractTestCase extends AbstractPackageTestCase
     /**
      * Get the service provider class.
      *
-     * @param  \Illuminate\Contracts\Foundation\Application $app
      * @return string
      */
-    protected function getServiceProviderClass($app)
+    protected function getServiceProviderClass()
     {
         return ServiceProvider::class;
     }

--- a/tests/Unit/WebhookCommandTest.php
+++ b/tests/Unit/WebhookCommandTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+class WebhookCommandTest extends AbstractTestCase
+{
+
+    /**
+    * @test
+    */
+    public function it_can_set_webhook()
+    {
+        $this->artisan('telegram:webhook https://example.com/test')
+            ->expectsOutput('Webhook set successfully!')
+            ->assertExitCode(0);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_show_webhook_info()
+    {
+        $this->artisan('telegram:webhook --info')
+            ->ExpectsOutput('Current webhook info:')
+            ->assertExitCode(0);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_delete_webhook()
+    {
+        $this->artisan('telegram:webhook --delete')
+            ->ExpectsOutput('Webhook deleted successfully!')
+            ->assertExitCode(0);
+    }
+}

--- a/tests/Unit/WebhookCommandTest.php
+++ b/tests/Unit/WebhookCommandTest.php
@@ -6,7 +6,6 @@ namespace Tests\Unit;
 
 class WebhookCommandTest extends AbstractTestCase
 {
-
     /**
     * @test
     */


### PR DESCRIPTION
Also:
- Dropped support for PHP 7.2.
- Added test for webhook command.
- Bumped up the longman/telegram-bot dependency to the latest version.
- Bumped up the graham-campbell/testbench dev dependency to the latest version.
- Bumped up the longman/php-code-style dev dependency to the latest version.
- Some coding style changes to comply with the new version of longman/php-code-style.